### PR TITLE
fix starttls and avoid "Unable to parse TLS packet header" exception

### DIFF
--- a/ImapNotes3/src/main/java/de/niendo/ImapNotes3/Data/Security.java
+++ b/ImapNotes3/src/main/java/de/niendo/ImapNotes3/Data/Security.java
@@ -28,9 +28,9 @@ public enum Security {
     @SuppressWarnings("unused")
     SSL_TLS_accept_all_certificates("SSL/TLS (accept all certificates)", "993", "imaps", true),
     @SuppressWarnings("unused")
-    STARTTLS("STARTTLS", "143", "imaps", false),
+    STARTTLS("STARTTLS", "143", "imap", false),
     @SuppressWarnings("unused")
-    STARTTLS_accept_all_certificates("STARTTLS (accept all certificates)", "143", "imaps", true);
+    STARTTLS_accept_all_certificates("STARTTLS (accept all certificates)", "143", "imap", true);
 
     @NonNull
     static final String TAG = "IN_Security";


### PR DESCRIPTION
Hi Peter,

configuring an account with STARTTLS always gave me an
"Unable to parse TLS packet header" exception
This is solved with my small changes to Security.java (protocoll has to be set to imap)

regards
Axel