### PR TITLE
Fix for certificate error reported when 'accept any certificate' selected

### DIFF
--- a/ImapNotes3/src/main/java/de/niendo/ImapNotes3/Sync/SyncUtils.java
+++ b/ImapNotes3/src/main/java/de/niendo/ImapNotes3/Sync/SyncUtils.java
@@ -164,7 +164,7 @@ public class SyncUtils {
         }
          */
         try {
-            Session session = Session.getDefaultInstance(props);
+            Session session = Session.getInstance(props, null);
             //session.setDebug(true);
             store = session.getStore(proto);
             store.connect(server, username, password);


### PR DESCRIPTION
If 'accept any certificate' is selected in the IMAP settings, sync nevertheless fails with a certificate error if the certificate is self-signed and cannot be validated.

The first time you run the app it works OK because it uses code in Imaper.java to log on to the server. Subsequent times it uses code in SyncUtil.java which fails. I have changed the one line of code which differs between the two. Probably the two sets of code could be merged.